### PR TITLE
feat(ui): agregar páginas de error 404 y 500 + nuevos íconos SVG

### DIFF
--- a/aulanet/apps/core/urls.py
+++ b/aulanet/apps/core/urls.py
@@ -7,6 +7,6 @@ urlpatterns = [
     path("", IndexView.as_view(), name="index"),
     path("contacto/", ContactView.as_view(), name="contact"),
     path("acerca-de/", AboutView.as_view(), name="about"),
-    path("not-found/", Error404View.as_view(), name="404"),
-    path("internal-server-error/", Error500View.as_view(), name="500"),
+    path("404/", NotFoundView.as_view(), name="404"),
+    path("500/", ServerErrorView.as_view(), name="500"),
 ]

--- a/aulanet/apps/core/views.py
+++ b/aulanet/apps/core/views.py
@@ -14,9 +14,17 @@ class ContactView(TemplateView):
     template_name = "core/contact.html"
 
 
-class Error404View(TemplateView):
+class NotFoundView(TemplateView):
     template_name = "core/errors/not-found.html"
 
 
-class Error500View(TemplateView):
+class ServerErrorView(TemplateView):
     template_name = "core/errors/internal-error.html"
+
+
+def custom_404(request, exception=None):
+    return render(request, "core/errors/not-found.html", status=404)
+
+
+def custom_500(request):
+    return render(request, "core/errors/internal-error.html", status=500)

--- a/aulanet/aulanet/urls.py
+++ b/aulanet/aulanet/urls.py
@@ -21,13 +21,16 @@ from django.conf import settings
 
 urlpatterns = [
     path("admin/", admin.site.urls),
-
     # APP ROUTES
     path("", include("apps.core.urls", namespace="core")),
     path("", include("apps.user.urls", namespace="user")),
     path("", include("apps.blog.urls", namespace="blog")),
     path("", include("apps.school.urls", namespace="school")),
 ]
+
+# Handlers para producción
+handler404 = "apps.core.views.custom_404"
+handler500 = "apps.core.views.custom_500"
 
 if settings.DEBUG:
     from django.conf.urls.static import static

--- a/aulanet/static/icons/animated/eye.svg
+++ b/aulanet/static/icons/animated/eye.svg
@@ -1,0 +1,7 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round">
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z" />
+    <circle cx="12" cy="12" r="3">
+        <animate attributeName="r" values="3;3.6;3" dur="2s" repeatCount="indefinite" />
+    </circle>
+</svg>

--- a/aulanet/static/icons/animated/heart.svg
+++ b/aulanet/static/icons/animated/heart.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 21s-8-5.5-8-12a5 5 0 0 1 9-3 5 5 0 0 1 9 3c0 6.5-8 12-8 12z">
+        <animate attributeName="stroke-width" values="2;2.8;2" dur="1.8s" repeatCount="indefinite" />
+    </path>
+</svg>

--- a/aulanet/static/icons/flat/404.svg
+++ b/aulanet/static/icons/flat/404.svg
@@ -1,0 +1,26 @@
+<!-- 404.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title404">
+    <title id="title404">Página 404 — No encontrada</title>
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="14">
+        <!-- Documento -->
+        <rect x="60" y="40" width="320" height="240" rx="14" ry="14" />
+        <path d="M60 110h320" />
+        <path d="M60 160h220" />
+        <path d="M60 210h180" />
+
+        <!-- Lupa -->
+        <circle cx="460" cy="160" r="80" />
+        <path d="M520 220 L560 260" />
+
+        <!-- Cruz pequeña dentro de lupa (indica "no encontrado") -->
+        <path d="M440 140 L480 180" stroke-width="10" />
+        <path d="M480 140 L440 180" stroke-width="10" />
+    </g>
+
+    <!-- Texto 404 -->
+    <g fill="currentColor" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial"
+        font-weight="700" text-anchor="middle">
+        <text x="200" y="330" font-size="56">404</text>
+        <text x="380" y="330" font-size="20" fill="currentColor" opacity="0.8">Página no encontrada</text>
+    </g>
+</svg>

--- a/aulanet/static/icons/flat/500.svg
+++ b/aulanet/static/icons/flat/500.svg
@@ -1,0 +1,32 @@
+<!-- 500.svg -->
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 600 400" role="img" aria-labelledby="title500">
+    <title id="title500">Error 500 — Error interno del servidor</title>
+
+    <!-- Rack / servidor -->
+    <g fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="12">
+        <rect x="60" y="40" width="400" height="300" rx="12" ry="12" />
+        <line x1="80" y1="90" x2="440" y2="90" />
+        <line x1="80" y1="150" x2="440" y2="150" />
+        <line x1="80" y1="210" x2="440" y2="210" />
+        <line x1="80" y1="270" x2="440" y2="270" />
+        <!-- LEDs -->
+        <circle cx="500" cy="100" r="8" fill="currentColor" />
+        <circle cx="500" cy="150" r="8" fill="currentColor" />
+        <circle cx="500" cy="200" r="8" fill="currentColor" />
+    </g>
+
+    <!-- Triángulo de alerta -->
+    <g transform="translate(280,40)">
+        <polygon points="0,0 50,86 -50,86" fill="none" stroke="currentColor" stroke-width="12"
+            stroke-linejoin="round" />
+        <line x1="0" y1="20" x2="0" y2="56" stroke="currentColor" stroke-width="10" />
+        <circle cx="0" cy="70" r="6" fill="currentColor" />
+    </g>
+
+    <!-- Texto 500 -->
+    <g fill="currentColor" font-family="system-ui, -apple-system, 'Segoe UI', Roboto, 'Helvetica Neue', Arial"
+        font-weight="700" text-anchor="middle">
+        <text x="300" y="360" font-size="56">500</text>
+        <text x="300" y="388" font-size="18" fill="currentColor" opacity="0.85">Error interno del servidor</text>
+    </g>
+</svg>

--- a/aulanet/static/icons/flat/home-flat.svg
+++ b/aulanet/static/icons/flat/home-flat.svg
@@ -1,0 +1,6 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100" height="100" viewBox="0 0 24 24" fill="none" stroke="currentColor"
+    stroke-width="1.5" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M2 12l10-9 10 9" />
+    <path d="M4 10v10a1 1 0 0 0 1 1h5v-6h4v6h5a1 1 0 0 0 1-1V10" />
+    <line x1="12" y1="15" x2="12" y2="15.01" />
+</svg>

--- a/aulanet/static/icons/outlined/eye.svg
+++ b/aulanet/static/icons/outlined/eye.svg
@@ -1,0 +1,5 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round">
+    <path d="M1 12s4-7 11-7 11 7 11 7-4 7-11 7S1 12 1 12z" />
+    <circle cx="12" cy="12" r="3" />
+</svg>

--- a/aulanet/static/icons/outlined/heart.svg
+++ b/aulanet/static/icons/outlined/heart.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2"
+    stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 21s-8-5.5-8-12a5 5 0 0 1 9-3 5 5 0 0 1 9 3c0 6.5-8 12-8 12z" />
+</svg>

--- a/aulanet/static/img/404.svg
+++ b/aulanet/static/img/404.svg
@@ -1,0 +1,29 @@
+<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .float {
+            animation: float 1.5s ease-in-out infinite;
+        }
+
+        @keyframes float {
+            0% {
+                transform: translateY(0px);
+            }
+
+            50% {
+                transform: translateY(-8px);
+            }
+
+            100% {
+                transform: translateY(0px);
+            }
+        }
+    </style>
+
+    <text x="50%" y="45%" text-anchor="middle" font-family="monospace" font-size="64" fill="#ff5757" class="float">
+        404
+    </text>
+
+    <text x="50%" y="70%" text-anchor="middle" font-family="monospace" font-size="20" fill="#444">
+        Página no encontrada
+    </text>
+</svg>

--- a/aulanet/static/img/500.svg
+++ b/aulanet/static/img/500.svg
@@ -1,0 +1,41 @@
+<svg width="300" height="200" viewBox="0 0 300 200" xmlns="http://www.w3.org/2000/svg">
+    <style>
+        .glitch {
+            animation: glitch 0.4s infinite;
+        }
+
+        @keyframes glitch {
+            0% {
+                transform: translate(0, 0);
+            }
+
+            20% {
+                transform: translate(-2px, 1px);
+            }
+
+            40% {
+                transform: translate(2px, -1px);
+            }
+
+            60% {
+                transform: translate(-1px, 2px);
+            }
+
+            80% {
+                transform: translate(1px, -2px);
+            }
+
+            100% {
+                transform: translate(0, 0);
+            }
+        }
+    </style>
+
+    <text x="50%" y="45%" text-anchor="middle" font-family="monospace" font-size="64" fill="#ffaa00" class="glitch">
+        500
+    </text>
+
+    <text x="50%" y="70%" text-anchor="middle" font-family="monospace" font-size="20" fill="#444">
+        Error interno del servidor
+    </text>
+</svg>

--- a/aulanet/templates/core/errors/internal-error.html
+++ b/aulanet/templates/core/errors/internal-error.html
@@ -1,12 +1,37 @@
 <!-- prettier-ignore -->
-{% extends 'layouts/base-layout.html' %}
+{% extends "layouts/general-layout.html" %}
+{% load static %}
 
-{% block title_layout %}
-    Error Interno del Servidor
-{% endblock title_layout %}
+{% block title %}Error del servidor - AulaNet{% endblock %}
 
-{% block content_layout %}
-<header>
-  <h1>Error Interno del Servidor</h1>
-</header>
-{% endblock content_layout %}
+{% block page_content %}
+
+<section
+  class="min-h-[70vh] flex flex-col items-center justify-center text-center px-6"
+>
+  <h1
+    class="font-main text-title text-[var(--color-main)] dark:text-white mb-4"
+  >
+    Algo salió mal
+  </h1>
+
+  <p class="font-secondary text-lg text-gray-600 dark:text-gray-300 max-w-lg">
+    El servidor tuvo un problema inesperado. Nuestro equipo ya está trabajando
+    para solucionarlo.
+  </p>
+
+  <img
+    src="{% static 'img/500.svg' %}"
+    alt="500"
+    class="w-64 h-auto my-10 opacity-90"
+  />
+
+  <a
+    href="{% url 'core:index' %}"
+    class="px-6 py-3 rounded bg-[var(--bg-button-primary)] text-white font-semibold hover:bg-[var(--bg-button-primary-hover)] transition"
+  >
+    Volver al inicio
+  </a>
+</section>
+
+{% endblock %}

--- a/aulanet/templates/core/errors/not-found.html
+++ b/aulanet/templates/core/errors/not-found.html
@@ -1,12 +1,66 @@
 <!-- prettier-ignore -->
-{% extends 'layouts/base-layout.html' %}
+{% extends "layouts/general-layout.html" %}
+{% load static %}
 
-{% block title_layout %}
-    Página no encontrada
-{% endblock title_layout %}
+{% block title %}Página no encontrada{% endblock %}
 
-{% block content_layout %}
-<header>
-  <h1>Página no encontrada</h1>
-</header>
-{% endblock content_layout %}
+{% block page_content %}
+<div
+  class="min-h-[70vh] flex flex-col items-center justify-center text-center px-6"
+  style="color: var(--color-main); font-family: var(--font-main)"
+>
+  <!-- Número 404 -->
+  <div class="mb-6">
+    <img
+      src="{% static 'img/404.svg' %}"
+      alt="404 — Página no encontrada"
+      class="w-80 mx-auto drop-shadow-md"
+    />
+  </div>
+
+  <!-- Ícono HOME -->
+  <div
+    class="mb-6 opacity-90 transition-transform duration-300 hover:scale-110"
+  >
+    <img
+      src="{% static 'icons/flat/home-flat.svg' %}"
+      class="w-20 mx-auto"
+      style="
+        filter: invert(26%) sepia(63%) saturate(2419%) hue-rotate(206deg)
+          brightness(90%) contrast(94%);
+      "
+    />
+  </div>
+
+  <!-- Título -->
+  <h1
+    class="font-bold mb-4"
+    style="font-size: var(--font-size-title); color: var(--color-secondary)"
+  >
+    404 — Página no encontrada
+  </h1>
+
+  <!-- Descripción -->
+  <p
+    class="mb-8"
+    style="font-size: var(--font-size-subtitle); max-width: 550px"
+  >
+    Parece que te perdiste. La página que buscás no existe o fue movida.
+  </p>
+
+  <!-- Botón -->
+  <a
+    href="/"
+    class="px-6 py-3 rounded-lg transition font-semibold shadow-md"
+    style="
+      background: var(--bg-button-primary);
+      font-size: var(--font-size-button);
+      color: white;
+    "
+    onmouseover="this.style.background='var(--bg-button-primary-hover)'"
+    onmouseout="this.style.background='var(--bg-button-primary)'"
+  >
+    Volver al inicio
+  </a>
+</div>
+{% endblock %}


### PR DESCRIPTION
- Se añaden los templates `404.html` y `500.html` con diseño moderno y estilos basados en variables del proyecto.
- Se incorporan animaciones suaves y estructura consistente con `general-layout`.
- Se agregan nuevos íconos SVG (incluyendo `home-flat.svg`) para mejorar la identidad visual.
- Se actualizan rutas estáticas y organización de la carpeta `static/img` y `static/icons`.