### PR TITLE
Remove redundant header from review-school template

### DIFF
--- a/aulanet/templates/school/review-school.html
+++ b/aulanet/templates/school/review-school.html
@@ -2,10 +2,6 @@
 {% extends 'layouts/base-layout.html' %}
 {% block title_layout %} Calificar Escuela {% endblock title_layout %}
 {% block content_layout %}
-<header>
-  <h1>Calificar Escuela</h1>
-</header>
-{% endblock content_layout %}
   <div class="w-full max-w-4xl shadow-2xl rounded-lg p-8 mx-auto" style="background: var(--bg-main); color: var(--color-main);">
         <form action="#" method="POST">
             


### PR DESCRIPTION
Se elimino en {% endblock content_layout %} que aparecia en medio del bloque. 