### PR TITLE
fix(user): corregir interacción del input de avatar en perfil

### DIFF
--- a/aulanet/apps/user/forms.py
+++ b/aulanet/apps/user/forms.py
@@ -66,13 +66,13 @@ class UserUpdateForm(forms.ModelForm):
             "city",
             "birthdate",
             "school",
-            "type",
+            "related_school",
             "avatar",
         ]
         labels = {
             "first_name": "Nombres",
             "last_name": "Apellidos",
-            "type": "Relación con el colegio",
+            "related_school": "Relación con el colegio",
             "birthdate": "Fecha de Nacimiento",
         }
 
@@ -83,7 +83,7 @@ class UserUpdateForm(forms.ModelForm):
             field.widget.attrs["class"] = INPUT_CLASSES
 
         self.fields["birthdate"].widget = forms.DateInput(
-            attrs={"type": "date", "class": INPUT_CLASSES}
+            format="%Y-%m-%d", attrs={"type": "date", "class": INPUT_CLASSES}
         )
 
         self.fields["avatar"].widget = FileInput(

--- a/aulanet/apps/user/forms.py
+++ b/aulanet/apps/user/forms.py
@@ -1,5 +1,6 @@
 from django import forms
 from django.contrib.auth.forms import AuthenticationForm, UserCreationForm
+from django.forms import FileInput
 from .models import User
 
 INPUT_CLASSES = (
@@ -85,6 +86,6 @@ class UserUpdateForm(forms.ModelForm):
             attrs={"type": "date", "class": INPUT_CLASSES}
         )
 
-        self.fields["avatar"].widget.attrs.update(
-            {"class": "hidden js-file-input", "id": "avatar"}
+        self.fields["avatar"].widget = FileInput(
+            attrs={"class": "hidden js-file-input", "id": "id_avatar"}
         )

--- a/aulanet/templates/user/user-update.html
+++ b/aulanet/templates/user/user-update.html
@@ -150,7 +150,7 @@
             class="block text-sm font-semibold text-gray-700 dark:text-gray-300 mb-1"
             >Relación con el Colegio</label
           >
-          {{ form.type }}
+          {{ form.related_school }}
         </div>
 
         <div class="flex items-center justify-end gap-4 pt-6 mt-4">


### PR DESCRIPTION
- Se reemplaza el widget ClearableFileInput por FileInput simple en UserUpdateForm para limpiar la UI.
- Se asegura la vinculación correcta entre el label y el input oculto (id_avatar).
- Soluciona el problema que impedía hacer clic para subir una nueva foto.