### PR TITLE
fix(auth): corregir bucle de redirección y mejorar flujo next en login/logout

### DIFF
--- a/aulanet/apps/user/views.py
+++ b/aulanet/apps/user/views.py
@@ -16,25 +16,48 @@ class AuthLoginView(LoginView):
 
     def get_success_url(self):
         next_url = self.request.POST.get("next") or self.request.GET.get("next")
-        if next_url and url_has_allowed_host_and_scheme(next_url, settings.ALLOWED_HOSTS):
+
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url, settings.ALLOWED_HOSTS
+        ):
             return next_url
-        return self.request.META.get("HTTP_REFERER") or reverse_lazy("core:index")
+
+        return reverse_lazy("core:index")
+
 
 class AuthRegisterView(CreateView):
     template_name = "auth/auth-register.html"
     form_class = RegisterForm
-    
-    def form_valid(self, form):
-        user = form.save()
-
-        next_url = self.request.POST.get("next") or self.request.GET.get("next")
-        if next_url and url_has_allowed_host_and_scheme(next_url, settings.ALLOWED_HOSTS):
-            return redirect(next_url)
-
-        return redirect(self.get_success_url())
 
     def get_success_url(self):
-        return reverse_lazy("user:login")
+        login_url = reverse_lazy("user:login")
+
+        # Recuperamos el 'next' que vino del formulario (POST) o de la URL (GET)
+        next_url = self.request.POST.get("next") or self.request.GET.get("next")
+
+        # Si existe y es seguro, lo pegamos a la URL del login
+        if next_url and url_has_allowed_host_and_scheme(
+            next_url, settings.ALLOWED_HOSTS
+        ):
+            return f"{login_url}?next={next_url}"
+
+        return login_url
+
+
+class CustomLogoutView(LogoutView):
+    def get_next_page(self):
+        # '?next='
+        next_url = self.request.GET.get("next")
+
+        if next_url and url_has_allowed_host_and_scheme(
+            url=next_url,
+            allowed_hosts=settings.ALLOWED_HOSTS,
+            require_https=self.request.is_secure(),
+        ):
+            return next_url
+
+        # Inicio por defecto
+        return reverse_lazy("core:index")
 
 
 class UserProfileView(LoginRequiredMixin, TemplateView):
@@ -49,11 +72,3 @@ class UserUpdateView(LoginRequiredMixin, UpdateView):
 
     def get_object(self):
         return self.request.user
-
-
-class CustomLogoutView(LogoutView):
-    def get_next_page(self):
-        next_url = self.request.GET.get("next")
-        if next_url and url_has_allowed_host_and_scheme(next_url, settings.ALLOWED_HOSTS):
-            return next_url
-        return self.request.META.get("HTTP_REFERER") or reverse_lazy("core:index")

--- a/aulanet/templates/auth/auth-login.html
+++ b/aulanet/templates/auth/auth-login.html
@@ -19,8 +19,12 @@
   <form method="POST" class="space-y-6">
     <!-- prettier-ignore -->
     {% csrf_token %}
-      <input type="hidden" name="next" value="{{ request.GET.next|default:request.META.HTTP_REFERER }}">
-      {% if form.non_field_errors %}
+    <input
+      type="hidden"
+      name="next"
+      value="{{ request.GET.next|default:request.META.HTTP_REFERER }}"
+    />
+    {% if form.non_field_errors %}
     <div
       class="bg-red-50 dark:bg-red-900/30 border border-red-200 dark:border-red-800 text-red-600 dark:text-red-300 px-4 py-3 rounded-lg text-sm flex items-center gap-2"
     >
@@ -72,7 +76,7 @@
       <p class="text-gray-600 dark:text-gray-400 text-sm">
         ¿No tienes cuenta?
         <a
-          href="{% url 'user:register' %}"
+          href="{% url 'user:register' %}{% if request.GET.next %}?next={{ request.GET.next }}{% endif %}"
           class="text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 font-semibold hover:underline transition-colors"
         >
           Regístrate aquí

--- a/aulanet/templates/auth/auth-register.html
+++ b/aulanet/templates/auth/auth-register.html
@@ -15,7 +15,10 @@
   <form method="POST" class="space-y-4">
     <!-- prettier-ignore -->
     {% csrf_token %}
-      <input type="hidden" name="next" value="{{ request.GET.next|default:request.META.HTTP_REFERER }}">
+      {% if request.GET.next %}
+    <input type="hidden" name="next" value="{{ request.GET.next }}" />
+    <!-- prettier-ignore -->
+    {% endif %}
       {% if form.non_field_errors %}
     <div
       class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded relative mb-4 text-sm"

--- a/aulanet/templates/components/ui/navbar.html
+++ b/aulanet/templates/components/ui/navbar.html
@@ -63,7 +63,11 @@
         </a>
 
         <!-- Botón de Logout (Formulario por seguridad) -->
-        <form action="{% url 'user:logout' %}" method="post" class="inline">
+        <form
+          action="{% url 'user:logout' %}?next={{ request.path }}"
+          method="post"
+          class="inline"
+        >
           {% csrf_token %}
           <button
             type="submit"
@@ -92,7 +96,7 @@
 
       <!-- Usuario NO Logueado -->
       <a
-        href="{% url 'user:login' %}"
+        href="{% url 'user:login' %}?next={{ request.path }}"
         class="text-sm font-bold px-5 py-2 bg-[var(--bg-button-primary)] text-white rounded-full hover:bg-[var(--bg-button-primary-hover)] transition shadow-md"
       >
         Login
@@ -156,7 +160,11 @@
       </a>
 
       <!-- Logout Mobile -->
-      <form action="{% url 'user:logout' %}" method="post" class="w-full">
+      <form
+        action="{% url 'user:logout' %}?next={{ request.path }}"
+        method="post"
+        class="w-full"
+      >
         {% csrf_token %}
         <button
           type="submit"
@@ -168,7 +176,7 @@
       {% else %}
       <!-- Login Mobile -->
       <a
-        href="{% url 'user:login' %}"
+        href="{% url 'user:login' %}?next={{ request.path }}"
         class="block mt-2 py-2 bg-[var(--bg-button-primary)] text-white text-center rounded hover:bg-[var(--bg-button-primary-hover)]"
       >
         Iniciar Sesión


### PR DESCRIPTION


- AuthLoginView: Se eliminó el uso de HTTP_REFERER para evitar bucles infinitos al fallar el login. Ahora prioriza el parámetro '?next='.
- AuthRegisterView: Se ajustó la lógica para pasar el parámetro 'next' a la pantalla de login tras un registro exitoso.
- CustomLogoutView: Se implementó vista para permitir que el usuario permanezca en la página actual al cerrar sesión.
- Templates: Se agregaron inputs ocultos en los formularios de login y registro para persistir la navegación del usuario.