### PR TITLE
feat(school): Implementar panel de administración de usuarios para colegios

### DIFF
--- a/aulanet/apps/core/urls.py
+++ b/aulanet/apps/core/urls.py
@@ -7,6 +7,7 @@ urlpatterns = [
     path("", IndexView.as_view(), name="index"),
     path("contacto/", ContactView.as_view(), name="contact"),
     path("acerca-de/", AboutView.as_view(), name="about"),
+    path("403/", PermissionDeniedView.as_view(), name="403"),
     path("404/", NotFoundView.as_view(), name="404"),
     path("500/", ServerErrorView.as_view(), name="500"),
     path("contact/send/", contact_send, name="contact_send"),

--- a/aulanet/apps/core/views.py
+++ b/aulanet/apps/core/views.py
@@ -9,9 +9,9 @@ from django.core.exceptions import ValidationError
 from django.contrib import messages
 from .forms import ContactForm
 
+
 class IndexView(TemplateView):
     template_name = "core/index.html"
-
 
     def get_context_data(self, **kwargs):
         context = super().get_context_data(**kwargs)
@@ -23,6 +23,8 @@ class IndexView(TemplateView):
         context["posts"] = Post.objects.order_by("-created_at")[:4]
 
         return context
+
+
 class AboutView(TemplateView):
     template_name = "core/about.html"
 
@@ -40,8 +42,16 @@ class NotFoundView(TemplateView):
     template_name = "core/errors/not-found.html"
 
 
+class PermissionDeniedView(TemplateView):
+    template_name = "core/errors/forbidden.html"
+
+
 class ServerErrorView(TemplateView):
     template_name = "core/errors/internal-error.html"
+
+
+def custom_403(request, exception):
+    return render(request, "core/errors/forbidden.html", status=403)
 
 
 def custom_404(request, exception=None):
@@ -68,7 +78,6 @@ def contact_send(request):
     email = form.cleaned_data["email"]
     subject = form.cleaned_data["subject"]
     message = form.cleaned_data["message"]
-        
 
     try:
         validate_email(email)

--- a/aulanet/apps/school/urls.py
+++ b/aulanet/apps/school/urls.py
@@ -8,4 +8,16 @@ urlpatterns = [
     path("escuela/listar/", ListSchoolView.as_view(), name="school-list"),
     path("escuela/calificar/", ReviewSchoolView.as_view(), name="review-school"),
     path("escuela/<slug:slug>/", SchoolDetailView.as_view(), name="school-detail"),
+    # --- URLS DE GESTIÓN DE USUARIOS DEL COLEGIO ---
+    path("mi-colegio/usuarios/", SchoolUserListView.as_view(), name="school-user-list"),
+    path(
+        "mi-colegio/usuarios/<uuid:pk>/actualizar-rol/",
+        UserRoleUpdateView.as_view(),
+        name="school-user-role-update",
+    ),
+    path(
+        "mi-colegio/usuarios/<uuid:pk>/eliminar/",
+        SchoolUserDeleteView.as_view(),
+        name="school-user-delete",
+    ),
 ]

--- a/aulanet/apps/school/views.py
+++ b/aulanet/apps/school/views.py
@@ -1,10 +1,21 @@
+from django.contrib import messages
+from django.contrib.auth.mixins import LoginRequiredMixin, UserPassesTestMixin
+from django.contrib.auth.models import Group
+from django.http import HttpResponseForbidden
 from django.shortcuts import render, get_object_or_404, redirect
 from django.views import View
-from django.views.generic import TemplateView, CreateView, DetailView
+from django.views.generic import (
+    TemplateView,
+    CreateView,
+    DetailView,
+    ListView,
+    DeleteView,
+)
 from .models import School, Review, SchoolRating
 from .forms import SchoolForm
 from django.urls import reverse, reverse_lazy
 from apps.blog.models import Post
+from apps.user.models import User
 
 
 # 1) Create (solo plantilla por ahora)
@@ -80,3 +91,107 @@ class SchoolDetailView(DetailView):
     def post(self, request, pk):
         # Sin ratings, solo redirigir al detalle
         return redirect("school:school-detail", pk=pk)
+
+
+# --- administración de usuarios del colegio (Admin role) -----
+
+
+# --- MIXIN DE PERMISOS ---
+class AdminRequiredMixin(UserPassesTestMixin):
+    """
+    Verifica que el usuario esté logueado y pertenezca al grupo 'Admin'.
+    """
+
+    def test_func(self):
+        return self.request.user.is_authenticated and (  # type: ignore
+            self.request.user.groups.filter(name="Admin").exists()  # type: ignore
+            or self.request.user.is_superuser  # type: ignore
+        )
+
+
+# --- LISTAR USUARIOS DEL COLEGIO ---
+class SchoolUserListView(LoginRequiredMixin, AdminRequiredMixin, ListView):
+    model = User
+    template_name = "school/admin/user_list.html"
+    context_object_name = "users"
+
+    def get_queryset(self):
+        """
+        Esta es la clave: Filtra los usuarios para mostrar solo los
+        del mismo colegio que el admin logueado.
+        También se excluye a sí mismo de la lista.
+        """
+        queryset = super().get_queryset()
+        return (
+            queryset.filter(school=self.request.user.school)  # type: ignore
+            .exclude(pk=self.request.user.pk)
+            .prefetch_related("groups")
+        )
+
+    def get_context_data(self, **kwargs):
+        """
+        Añade los roles disponibles al contexto para rellenar el
+        menú desplegable en la plantilla.
+        """
+        context = super().get_context_data(**kwargs)
+        # Un Admin de colegio solo puede asignar roles inferiores, nunca 'Admin'.
+        context["available_groups"] = Group.objects.filter(
+            name__in=["Registered", "Contributor"]
+        )
+        return context
+
+
+# --- PROCESAR EL CAMBIO DE ROL ---
+class UserRoleUpdateView(LoginRequiredMixin, AdminRequiredMixin, View):
+    def post(self, request, pk):
+        # Obtener el usuario que se va a modificar
+        target_user = get_object_or_404(User, pk=pk)
+
+        # Asegurarse de que el admin no modifique usuarios de otros colegios
+        if target_user.school != request.user.school or target_user.is_superuser:
+            return HttpResponseForbidden(
+                "No tienes permiso para modificar a este usuario."
+            )
+
+        new_group_id = request.POST.get("group")
+        if not new_group_id:
+            messages.error(request, "No se seleccionó un nuevo rol.")
+            return redirect("school:school-user-list")
+
+        new_group = get_object_or_404(Group, pk=new_group_id)
+
+        # no permitir promover a Admin
+        if new_group.name not in ["Registered", "Contributor"]:
+            return HttpResponseForbidden("No se puede asignar este rol.")
+
+        # Asignar el nuevo rol (eliminando los anteriores)
+        target_user.groups.clear()
+        target_user.groups.add(new_group)
+
+        messages.success(
+            request,
+            f"Se actualizó el rol de {target_user.username} a {new_group.name}.",
+        )
+        return redirect("school:school-user-list")
+
+
+# --- 4. VISTA PARA ELIMINAR UN USUARIO ---
+class SchoolUserDeleteView(LoginRequiredMixin, AdminRequiredMixin, DeleteView):
+    model = User
+    template_name = "school/admin/user_delete_confirm.html"
+    success_url = reverse_lazy("school:school-user-list")
+    context_object_name = "user_to_delete"
+
+    def get_queryset(self):
+        """
+        Asegura que un admin solo pueda ver la página de confirmación
+        para usuarios de su propio colegio.
+        """
+        queryset = super().get_queryset()
+        return queryset.filter(school=self.request.user.school)  # type: ignore
+
+    def form_valid(self, form):
+        messages.success(
+            self.request, f"El usuario {self.object.username} ha sido eliminado."  # type: ignore
+        )
+        return super().form_valid(form)  # type: ignore

--- a/aulanet/aulanet/urls.py
+++ b/aulanet/aulanet/urls.py
@@ -29,6 +29,7 @@ urlpatterns = [
 ]
 
 # Handlers para producción
+handler403 = "apps.core.views.custom_403"
 handler404 = "apps.core.views.custom_404"
 handler500 = "apps.core.views.custom_500"
 
@@ -37,3 +38,12 @@ if settings.DEBUG:
 
     urlpatterns += static(settings.STATIC_URL, document_root=settings.STATIC_ROOT)
     urlpatterns += static(settings.MEDIA_URL, document_root=settings.MEDIA_ROOT)
+
+    # Rutas de previsualización de errores solo para desarrollo
+    from apps.core import views as core_views
+
+    urlpatterns += [
+        path("403-preview/", core_views.PermissionDeniedView.as_view()),
+        path("404-preview/", core_views.NotFoundView.as_view()),
+        path("500-preview/", core_views.ServerErrorView.as_view()),
+    ]

--- a/aulanet/static/img/403.svg
+++ b/aulanet/static/img/403.svg
@@ -1,0 +1,53 @@
+<svg width="400" height="200" viewBox="0 0 400 200" xmlns="http://www.w3.org/2000/svg">
+    <defs>
+        <linearGradient id="grad" x1="0%" y1="0%" x2="100%" y2="0%">
+            <stop offset="0%" stop-color="#ff5f6d" />
+            <stop offset="100%" stop-color="#ffc371" />
+        </linearGradient>
+        <style>
+            @keyframes float {
+                0% {
+                    transform: translateY(0px);
+                }
+
+                50% {
+                    transform: translateY(-8px);
+                }
+
+                100% {
+                    transform: translateY(0px);
+                }
+            }
+
+            @keyframes blink {
+
+                0%,
+                100% {
+                    opacity: 1;
+                }
+
+                50% {
+                    opacity: 0.2;
+                }
+            }
+        </style>
+    </defs>
+
+    <rect width="100%" height="100%" fill="#fafafa" />
+
+    <!-- Círculo decorativo animado -->
+    <circle cx="200" cy="100" r="70" fill="url(#grad)" opacity="0.25"
+        style="animation: float 3s ease-in-out infinite;" />
+
+    <!-- Texto 403 animado -->
+    <text x="50%" y="50%" dominant-baseline="middle" text-anchor="middle" font-size="70" font-family="Arial Black"
+        fill="url(#grad)" style="animation: float 2.2s ease-in-out infinite;">
+        403
+    </text>
+
+    <!-- Leyenda -->
+    <text x="50%" y="75%" dominant-baseline="middle" text-anchor="middle" font-size="22" font-family="Arial" fill="#444"
+        style="animation: blink 2s infinite;">
+        Acceso denegado
+    </text>
+</svg>

--- a/aulanet/templates/components/ui/navbar.html
+++ b/aulanet/templates/components/ui/navbar.html
@@ -27,10 +27,21 @@
         class="text-lg text-gray-200 hover:text-white transition"
         >Colegios</a
       >
+      <!-- prettier-ignore -->
+      {% if user.is_authenticated %}
+        {% for group in user.groups.all %}
+            {% if group.name == 'Admin' %}
+      <a href="{% url 'school:school-user-list' %}" class="nav-link">
+        Administrar Usuarios
+      </a>
+      <!-- prettier-ignore -->
+      {% endif %}
+        {% endfor %}
+      {% endif %}
       <a
-      href="{% url 'blog:post-list' %}"
-      class="text-lg text-gray-200 hover:text-white transition"
-      >Posts</a
+        href="{% url 'blog:post-list' %}"
+        class="text-lg text-gray-200 hover:text-white transition"
+        >Posts</a
       >
 
       <a
@@ -136,10 +147,21 @@
       class="block py-2 px-2 text-gray-200 hover:text-white hover:bg-white/10 rounded"
       >Colegios</a
     >
+    <!-- prettier-ignore -->
+    {% if user.is_authenticated %}
+        {% for group in user.groups.all %}
+            {% if group.name == 'Admin' %}
+    <a href="{% url 'school:school-user-list' %}" class="nav-link">
+      Administrar Usuarios
+    </a>
+    <!-- prettier-ignore -->
+    {% endif %}
+        {% endfor %}
+    {% endif %}
     <a
-    href="{% url 'blog:post-list' %}"
-    class="block py-2 px-2 text-gray-200 hover:text-white hover:bg-white/10 rounded"
-    >Posts</a
+      href="{% url 'blog:post-list' %}"
+      class="block py-2 px-2 text-gray-200 hover:text-white hover:bg-white/10 rounded"
+      >Posts</a
     >
 
     <a

--- a/aulanet/templates/core/errors/forbidden.html
+++ b/aulanet/templates/core/errors/forbidden.html
@@ -1,0 +1,49 @@
+<!-- prettier-ignore -->
+{% extends "layouts/general-layout.html" %}
+{% load static %}
+
+{% block title %}Acceso Denegado{% endblock %}
+
+{% block page_content %}
+<div
+  class="min-h-[70vh] flex flex-col items-center justify-center text-center px-6"
+  style="color: var(--color-main); font-family: var(--font-main)"
+>
+  <div class="mb-6">
+    <img
+      src="{% static 'img/403.svg' %}"
+      alt="403 — Acceso Denegado"
+      class="w-80 mx-auto drop-shadow-md"
+    />
+  </div>
+
+  <h1
+    class="font-bold mb-4"
+    style="font-size: var(--font-size-title); color: var(--color-secondary)"
+  >
+    403 — Acceso Denegado
+  </h1>
+
+  <p
+    class="mb-8"
+    style="font-size: var(--font-size-subtitle); max-width: 550px"
+  >
+    No tienes los permisos necesarios para acceder a esta página. Por favor,
+    contacta a un administrador si crees que es un error.
+  </p>
+
+  <a
+    href="/"
+    class="px-6 py-3 rounded-lg transition font-semibold shadow-md"
+    style="
+      background: var(--bg-button-primary);
+      font-size: var(--font-size-button);
+      color: white;
+    "
+    onmouseover="this.style.background='var(--bg-button-primary-hover)'"
+    onmouseout="this.style.background='var(--bg-button-primary)'"
+  >
+    Volver al inicio
+  </a>
+</div>
+{% endblock %}

--- a/aulanet/templates/school/admin/user_delete_confirm.html
+++ b/aulanet/templates/school/admin/user_delete_confirm.html
@@ -1,0 +1,36 @@
+<!-- prettier-ignore -->
+{% extends "layouts/general-layout.html" %}
+
+{% block title %}Confirmar Eliminación{% endblock %}
+
+{% block page_content %}
+<section class="container mx-auto px-4 py-8 max-w-lg">
+  <div class="bg-white dark:bg-slate-800 p-8 rounded-lg shadow-md">
+    <h1 class="text-2xl font-bold mb-4 dark:text-white">
+      Confirmar Eliminación
+    </h1>
+    <p class="mb-6 dark:text-gray-300">
+      ¿Estás seguro de que quieres eliminar permanentemente al usuario
+      <strong class="text-red-500">{{ user_to_delete.username }}</strong>? Esta
+      acción no se puede deshacer.
+    </p>
+    <form method="POST">
+      {% csrf_token %}
+      <div class="flex justify-end gap-4">
+        <a
+          href="{% url 'school:school-user-list' %}"
+          class="px-4 py-2 rounded-lg text-gray-700 bg-gray-200 hover:bg-gray-300 dark:bg-slate-600 dark:text-white dark:hover:bg-slate-500"
+        >
+          Cancelar
+        </a>
+        <button
+          type="submit"
+          class="px-4 py-2 rounded-lg text-white bg-red-600 hover:bg-red-700"
+        >
+          Sí, eliminar
+        </button>
+      </div>
+    </form>
+  </div>
+</section>
+{% endblock %}

--- a/aulanet/templates/school/admin/user_list.html
+++ b/aulanet/templates/school/admin/user_list.html
@@ -1,0 +1,57 @@
+<!-- prettier-ignore -->
+{% extends "layouts/general-layout.html" %}
+
+{% block title %}Administrar Usuarios del Colegio{% endblock %}
+
+{% block page_content %}
+<div class="container mx-auto px-4 py-8">
+    <h1 class="text-3xl font-bold mb-6 dark:text-white">Administrar Usuarios de {{ user.school.name }}</h1>
+
+    <div class="bg-white dark:bg-slate-800 rounded-lg shadow overflow-x-auto">
+        <table class="w-full text-sm text-left text-gray-500 dark:text-gray-400">
+            <thead class="text-xs text-gray-700 uppercase bg-gray-50 dark:bg-slate-700 dark:text-gray-400">
+                <tr>
+                    <th scope="col" class="px-6 py-3">Usuario</th>
+                    <th scope="col" class="px-6 py-3">Nombre Completo</th>
+                    <th scope="col" class="px-6 py-3">Rol Actual</th>
+                    <th scope="col" class="px-6 py-3">Cambiar Rol</th>
+                    <th scope="col" class="px-6 py-3">Acciones</th>
+                </tr>
+            </thead>
+            <tbody>
+                {% for user_to_manage in users %}
+                <tr class="bg-white dark:bg-slate-800 border-b dark:border-slate-700 hover:bg-gray-50 dark:hover:bg-slate-600">
+                    <td class="px-6 py-4 font-medium text-gray-900 dark:text-white">{{ user_to_manage.username }}</td>
+                    <td class="px-6 py-4">{{ user_to_manage.get_full_name|default:"-" }}</td>
+                    <td class="px-6 py-4">
+                        <span class="px-2 py-1 text-xs font-medium rounded-full bg-blue-100 text-blue-800 dark:bg-blue-900 dark:text-blue-300">
+                            {{ user_to_manage.groups.first.name|default:"Sin rol" }}
+                        </span>
+                    </td>
+                    <td class="px-6 py-4">
+                        <form action="{% url 'school:school-user-role-update' user_to_manage.pk %}" method="POST" class="flex items-center gap-2">
+                            {% csrf_token %}
+                            <select name="group" class="bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-slate-700 dark:border-slate-600 dark:placeholder-slate-400 dark:text-white">
+                                {% for group in available_groups %}
+                                    <option value="{{ group.pk }}" {% if user_to_manage.groups.first.pk == group.pk %}selected{% endif %}>
+                                        {{ group.name }}
+                                    </option>
+                                {% endfor %}
+                            </select>
+                            <button type="submit" class="text-white bg-blue-600 hover:bg-blue-700 font-medium rounded-lg text-sm px-4 py-2">Guardar</button>
+                        </form>
+                    </td>
+                    <td class="px-6 py-4">
+                        <a href="{% url 'school:school-user-delete' user_to_manage.pk %}" class="font-medium text-red-600 dark:text-red-500 hover:underline">Eliminar</a>
+                    </td>
+                </tr>
+                {% empty %}
+                <tr>
+                    <td colspan="5" class="px-6 py-4 text-center">No hay otros usuarios en este colegio.</td>
+                </tr>
+                {% endfor %}
+            </tbody>
+        </table>
+    </div>
+</div>
+{% endblock %}


### PR DESCRIPTION
Este commit introduce una funcionalidad completa que permite a los usuarios del grupo "Admin" gestionar a los miembros de su propio colegio, junto con mejoras significativas en la organización del código y el manejo de errores.

Funcionalidad Principal:
- Se crea una nueva página donde los administradores de un colegio pueden listar a todos los usuarios de su institución.
- Desde esta página, pueden cambiar el rol de un usuario entre "Registered" y "Contributor".
- También pueden eliminar usuarios de su colegio a través de un flujo de confirmación seguro.
- El acceso está protegido por un nuevo `AdminRequiredMixin` para garantizar la seguridad.

Mejoras de Arquitectura y UI:
- Toda la lógica (URLs, Vistas, Plantillas) fue refactorizada desde la app `user` a la app `school`, ya que conceptualmente pertenece a la gestión de un colegio.
- Las plantillas de administración se han organizado en una subcarpeta `school/admin/` para mayor claridad.
- Se ha corregido la lógica en la barra de navegación para mostrar el enlace de "Administrar Usuarios" de forma robusta, sin depender del orden de los grupos.

Manejo de Errores:
- Se ha implementado una vista y plantilla personalizada para el error "403 Forbidden", mejorando la experiencia del usuario al intentar acceder a una página sin permisos.
- Se han añadido URLs de previsualización para las páginas de error (403, 404, 500) que solo se activan en modo DEBUG, facilitando su diseño y desarrollo.