### PR TITLE
feat(blog): Implementar lógica de comentarios y mejorar permisos de gestión

### DIFF
--- a/aulanet/apps/blog/views.py
+++ b/aulanet/apps/blog/views.py
@@ -129,6 +129,8 @@ class PostDetailView(DetailView):
         context["comments"] = self.object.comments.select_related("author").order_by(  # type: ignore
             "-created_at"
         )
+        if self.object.allow_comments:  # type: ignore
+            context["comment_form"] = CommentForm()
         return context
 
 

--- a/aulanet/templates/blog/post-detail.html
+++ b/aulanet/templates/blog/post-detail.html
@@ -144,6 +144,7 @@
 
   <!-- SECCIÓN DE COMENTARIOS -->
   <section class="mt-12">
+    {% if post.allow_comments %}
     <h3 class="text-2xl font-bold text-gray-800 dark:text-white mb-6">
       Comentarios ({{ comments.count }})
     </h3>
@@ -160,12 +161,11 @@
       <form method="POST" action="{% url 'blog:comment-create' post.slug %}">
         {% csrf_token %}
         <div class="mb-4">
-          <textarea
-            name="content"
-            rows="3"
-            class="w-full p-3 rounded-lg border border-gray-300 dark:border-slate-600 dark:bg-slate-700 dark:text-white focus:ring-2 focus:ring-blue-500 focus:border-transparent"
-            placeholder="Escribe tu opinión..."
-          ></textarea>
+          <!-- prettier-ignore -->
+          {{ comment_form.content }}
+            {% for error in comment_form.content.errors %}
+          <p class="text-red-500 text-sm mt-1">{{ error }}</p>
+          {% endfor %}
         </div>
         <div class="flex justify-end">
           <button
@@ -212,6 +212,17 @@
       <p class="text-gray-500 italic text-center">Sé el primero en comentar.</p>
       {% endfor %}
     </div>
+
+    {% else %}
+
+    <!-- Mensaje que se muestra si los comentarios están desactivados -->
+    <div class="bg-gray-100 dark:bg-slate-800 p-6 rounded-lg text-center">
+      <p class="text-gray-600 dark:text-gray-400 font-medium">
+        Los comentarios para esta publicación han sido desactivados.
+      </p>
+    </div>
+
+    {% endif %}
   </section>
 </div>
 

--- a/aulanet/templates/components/commons/comment-card.html
+++ b/aulanet/templates/components/commons/comment-card.html
@@ -24,10 +24,10 @@
 
       <!-- BOTONES DE ACCIÓN -->
       <!-- prettier-ignore -->
-      {% if request.user == comment.author or request.user == comment.post.author or perms.school.change_school and request.user.school == comment.post.school %}
+      {% if request.user == comment.author or request.user == comment.post.author or perms.school.change_school and request.user.school == comment.post.school or request.user.is_superuser %}
       <div class="flex gap-2">
         <!-- Botón Editar -->
-        {% if request.user == comment.author %}
+        {% if request.user == comment.author or request.user.is_superuser %}
         <button
           onclick="toggleEditComment('{{ comment.id }}')"
           class="text-gray-400 hover:text-blue-500 transition"


### PR DESCRIPTION
Este commit introduce varias mejoras clave en la funcionalidad y la interfaz de la sección de comentarios del blog para que se comporte como se espera.

- **Aplicar la opción "Permitir Comentarios":** Se implementa la lógica en la vista y la plantilla `post-detail.html` para mostrar u ocultar completamente la sección de comentarios basándose en el valor del campo `allow_comments` del post.

- **Mejorar Permisos de Gestión:** Se corrige y amplía la condición en la plantilla `comment-card.html`. Ahora, además del autor, los Superusuarios y los Administradores del colegio correspondiente también pueden ver los botones para editar y eliminar comentarios.

- **Refactorizar Formulario de Comentarios:** El formulario para crear un nuevo comentario ha sido refactorizado para usar el renderizado de Django (`{{ comment_form.content }}`) en lugar de un `<textarea>` manual. Esto mejora drásticamente el manejo de errores y el repoblado de datos en caso de que la validación falle.