### PR TITLE
feat(blog): Implementar lightbox para la galería de imágenes del post

### DIFF
--- a/aulanet/static/js/main.js
+++ b/aulanet/static/js/main.js
@@ -87,6 +87,42 @@ document.addEventListener('DOMContentLoaded', () => {
       }
     });
   });
+
+  // --- Image Gallery Modal ---
+  const imageModal = document.getElementById('imageModal');
+  const galleryImages = document.querySelectorAll('.gallery-image');
+
+  if (imageModal && galleryImages.length > 0) {
+    const modalImage = document.getElementById('modalImage');
+    const closeModalBtn = document.getElementById('closeModalBtn');
+    const modalBackdrop = document.getElementById('modalBackdrop');
+
+    const openModal = (src) => {
+      modalImage.src = src;
+      imageModal.classList.remove('hidden');
+      document.body.style.overflow = 'hidden';
+    };
+
+    const closeModal = () => {
+      imageModal.classList.add('hidden');
+      document.body.style.overflow = 'auto';
+    };
+
+    galleryImages.forEach((img) => {
+      img.addEventListener('click', () => {
+        openModal(img.src);
+      });
+    });
+
+    closeModalBtn?.addEventListener('click', closeModal);
+    modalBackdrop?.addEventListener('click', closeModal);
+
+    document.addEventListener('keydown', (event) => {
+      if (event.key === 'Escape' && !imageModal.classList.contains('hidden')) {
+        closeModal();
+      }
+    });
+  }
 });
 
 // Editar comentarios

--- a/aulanet/templates/blog/post-detail.html
+++ b/aulanet/templates/blog/post-detail.html
@@ -113,7 +113,7 @@
         {% for img in post.images.all %}
         <img
           src="{{ img.image.url }}"
-          class="rounded-lg shadow-sm w-full h-40 object-cover hover:opacity-90 transition cursor-pointer"
+          class="gallery-image rounded-lg shadow-sm w-full h-40 object-cover hover:opacity-90 hover:scale-105 transform transition-all duration-300 cursor-pointer"
         />
         {% endfor %}
       </div>
@@ -308,6 +308,57 @@
           </button>
         </div>
       </div>
+    </div>
+  </div>
+</div>
+
+<!-- =============================================== -->
+<!--         NUEVO MODAL PARA VER IMÁGENES           -->
+<!-- =============================================== -->
+<div
+  id="imageModal"
+  class="relative z-50 hidden"
+  aria-labelledby="modal-title"
+  role="dialog"
+  aria-modal="true"
+>
+  <!-- Fondo oscuro -->
+  <div
+    id="modalBackdrop"
+    class="fixed inset-0 bg-gray-900/80 transition-opacity backdrop-blur-sm"
+  ></div>
+
+  <div class="fixed inset-0 z-10 w-screen overflow-y-auto">
+    <div class="flex min-h-full items-center justify-center p-4 text-center">
+      <!-- Contenedor de la imagen -->
+      <div class="relative transform transition-all">
+        <img
+          id="modalImage"
+          src=""
+          class="max-h-[90vh] max-w-[90vw] rounded-lg shadow-2xl"
+          alt="Vista ampliada"
+        />
+      </div>
+      <!-- Botón para cerrar -->
+      <button
+        id="closeModalBtn"
+        class="absolute top-4 right-4 text-white hover:text-gray-300 transition"
+      >
+        <svg
+          class="w-8 h-8"
+          fill="none"
+          stroke="currentColor"
+          viewBox="0 0 24 24"
+          xmlns="http://www.w3.org/2000/svg"
+        >
+          <path
+            stroke-linecap="round"
+            stroke-linejoin="round"
+            stroke-width="2"
+            d="M6 18L18 6M6 6l12 12"
+          ></path>
+        </svg>
+      </button>
     </div>
   </div>
 </div>


### PR DESCRIPTION
Este commit introduce una galería de imágenes interactiva en la página de detalle del post, mejorando significativamente la experiencia de visualización para el usuario.

- **Funcionalidad de Lightbox:** Las imágenes en la sección "Galería de Imágenes" ahora son clickables. Al hacer clic, se abre un modal (lightbox) a pantalla completa que muestra la imagen en alta resolución.
- **Interactividad:** El modal se puede cerrar haciendo clic en el fondo, en un botón de X, o presionando la tecla Escape.
- **Efecto Visual:** Se ha añadido un sutil efecto de zoom al pasar el cursor sobre las imágenes de la galería para indicar su interactividad.
- **Refactorización de JavaScript:** La lógica del lightbox se ha integrado de forma limpia en el archivo principal `main.js` dentro del listener `DOMContentLoaded`, en lugar de usar un script inline en la plantilla. Esto mejora el rendimiento y la mantenibilidad.